### PR TITLE
release: v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cosmonic-labs/mcp-server-template",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cosmonic-labs/mcp-server-template",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@bytecodealliance/componentize-js": "^0.18.4",
         "@bytecodealliance/jco": "^1.13.0",
-        "@cosmonic-labs/openapi2mcp": "0.8.0",
+        "@cosmonic-labs/openapi2mcp": "0.9.0",
         "@eslint/js": "^9.24.0",
         "@modelcontextprotocol/inspector": "^0.16.3",
         "@rollup/plugin-alias": "^5.1.0",
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@cosmonic-labs/openapi2mcp": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cosmonic-labs/openapi2mcp/-/openapi2mcp-0.8.0.tgz",
-      "integrity": "sha512-QM8v7Ne9W2doEGYvcTpPGhHAMWRExwTHPU+bwtAcoZM3SsnEbnMqVnQjo2hhiErk7IcKmljHBruE600sm0TjMA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@cosmonic-labs/openapi2mcp/-/openapi2mcp-0.9.0.tgz",
+      "integrity": "sha512-2GZiT68gYMABbQHgD5rJlyxfQq1j3E0V1QFuNpTp8PiSXieO8r79wq4YRLKC+ig7ka59IsSQnGTeja7SI/mDUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmonic-labs/mcp-server-template",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Template for MCP Servers",
   "keywords": [
     "wasm",
@@ -51,7 +51,7 @@
     "@bytecodealliance/jco": "^1.13.0",
     "@eslint/js": "^9.24.0",
     "@modelcontextprotocol/inspector": "^0.16.3",
-    "@cosmonic-labs/openapi2mcp": "0.8.0",
+    "@cosmonic-labs/openapi2mcp": "0.9.0",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^27.0.0",
     "@rollup/plugin-json": "^6.1.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+export const SERVER_NAME = "my-mcp-server";
+export const SERVER_VERSION = "1.0.0";
 // TODO: Configure these URLs for your OAuth provider
 export const API_BASE_URL = ""; // e.g., "https://api.example.com"
 export const OAUTH_AUTHORIZATION_URL = ""; // e.g., "https://example.com/oauth/authorize"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const SERVER_NAME = "my-mcp-server";
-export const SERVER_VERSION = "1.0.0";
+export const SERVER_VERSION = "1.1.0";
 // TODO: Configure these URLs for your OAuth provider
 export const API_BASE_URL = ""; // e.g., "https://api.example.com"
 export const OAUTH_AUTHORIZATION_URL = ""; // e.g., "https://example.com/oauth/authorize"

--- a/src/routes/v1/mcp/index.ts
+++ b/src/routes/v1/mcp/index.ts
@@ -1,7 +1,6 @@
 import type { Hono } from "hono";
-import { MCPServer } from "./server";
-import { MCP_SERVER_BASE_PATH } from "../../../config";
+import { setupMCPRoutes } from "./server";
 
 export function setupRoutes(app: Hono) {
-  app.post(MCP_SERVER_BASE_PATH, MCPServer.handleMCPRequest);
+  setupMCPRoutes(app);
 }

--- a/src/routes/v1/mcp/resources/greeting.ts
+++ b/src/routes/v1/mcp/resources/greeting.ts
@@ -1,8 +1,8 @@
-import { MCPServer } from "../server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 
-export function setupResource(server: MCPServer) {
+export function setupResource(server: McpServer) {
   // Create a simple resource at a fixed URI
   server.resource(
     "greeting-resource",

--- a/src/routes/v1/mcp/resources/index.ts
+++ b/src/routes/v1/mcp/resources/index.ts
@@ -1,7 +1,7 @@
-import { MCPServer } from "../server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import * as greetingResource from "./greeting";
+import { setupResource } from "./greeting";
 
-export function setupAllResources(server: MCPServer) {
-  greetingResource.setupResource(server);
+export function setupAllResources(server: McpServer) {
+  setupResource(server);
 }

--- a/src/routes/v1/mcp/server.ts
+++ b/src/routes/v1/mcp/server.ts
@@ -1,52 +1,31 @@
-import { McpServer as UpstreamMCPServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Hono, Context } from "hono";
 import { StreamableHTTPTransport } from "@hono/mcp";
-import { Context } from "hono";
+import { SERVER_NAME, SERVER_VERSION } from "../../../constants";
+import { setupAllTools } from "./tools/index";
+import { setupAllResources } from "./resources/index";
 
-import { setupAllTools } from "./tools";
-import { setupAllResources } from "./resources";
+export const MCP_BASE_PATH = "/v1/mcp";
 
-export class MCPServer extends UpstreamMCPServer {
-  constructor(opts: any) {
-    super(opts);
-    const server = this;
-    setupAllTools(server);
-    setupAllResources(server);
-  }
+const mcpServer = new McpServer({
+  name: SERVER_NAME,
+  version: SERVER_VERSION,
+});
+setupAllTools(mcpServer);
+setupAllResources(mcpServer);
 
-  /**
-   * Handle HTTP requests for MCP communication (stateless)
-   */
-  static async handleMCPRequest(c: Context) {
-    const method = c.req.method;
+const transport = new StreamableHTTPTransport({
+  sessionIdGenerator: undefined,
+  enableDnsRebindingProtection: true,
+  // allowedHosts: ['127.0.0.1'],
+});
 
-    // Only POST is supported right now
-    if (method !== "POST") {
-      return c.text("Method not allowed", 405);
+export function setupMCPRoutes(app: Hono) {
+  app.post(MCP_BASE_PATH, async (context: Context) => {
+    if (!mcpServer.isConnected()) {
+      await mcpServer.connect(transport);
     }
 
-    // Handle POST requests (JSON-RPC messages)
-    const body = await c.req.json();
-
-    // Create a new transport and server for each request (stateless approach)
-    // This ensures each request is handled independently without relying on stored state
-    const transport = new StreamableHTTPTransport({
-      sessionIdGenerator: undefined,
-
-      // DNS rebinding protection is disabled by default for backwards compatibility.
-      enableDnsRebindingProtection: true,
-      // allowedHosts: ['127.0.0.1'],
-    });
-
-    // TODO: Transport generation/hydration as a Hono middleware?
-
-    const server = new MCPServer({
-      name: "example-server",
-      version: "1.0.0",
-    });
-    await server.connect(transport as any);
-
-    const response = await transport.handleRequest(c, body);
-    return response || c.text("OK");
-  }
+    return await transport.handleRequest(context);
+  });
 }

--- a/src/routes/v1/mcp/tools/echo.ts
+++ b/src/routes/v1/mcp/tools/echo.ts
@@ -1,8 +1,8 @@
 import z from "zod";
 
-import { MCPServer } from "../server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-export function setupTool(server: MCPServer) {
+export function setupTool(server: McpServer) {
   // Register a tool specifically for testing resumability
   server.tool(
     "echo",

--- a/src/routes/v1/mcp/tools/index.ts
+++ b/src/routes/v1/mcp/tools/index.ts
@@ -1,7 +1,7 @@
-import { MCPServer } from "../server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import * as startNotificationStream from "./echo";
 
-export function setupAllTools(server: MCPServer) {
+export function setupAllTools(server: McpServer) {
   startNotificationStream.setupTool(server);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors MCP HTTP handling to use a single persistent `McpServer` with a shared `StreamableHTTPTransport`, consolidating route setup.
> 
> - Replaces custom `MCPServer` class with SDK `McpServer`; adds `setupMCPRoutes` and sets `MCP_BASE_PATH` to `/v1/mcp`
> - Initializes server with `SERVER_NAME` and `SERVER_VERSION` from new `src/constants.ts` (also adds OAuth URL placeholders)
> - Updates tools/resources to use SDK `McpServer` types and new setup functions; includes `echo` tool and `greeting` resource
> - Bumps package version to `1.1.0` and updates `@cosmonic-labs/openapi2mcp` dev dependency to `0.9.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec11ec8fda536478cd21502df4d4ad0f0744634a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->