### PR TITLE
fix: wse `guest-types` in generate:types npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "fetch:wit": "wash wit fetch",
-    "generate:types": "rimraf generated/types && jco types wit/ -o generated/types",
+    "generate:types": "rimraf generated/types && jco guest-types wit/ -o generated/types",
     "setup:wit": "npm run fetch:wit && npm run generate:types",
     "build:ts": "rollup -c",
     "build:component": "jco componentize -w wit -o dist/component.wasm dist/component.js",


### PR DESCRIPTION
This project is a guest, so needs guest-types